### PR TITLE
Make no_std compatible

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![no_std]
 //! A simple macro that embeds the bytes of an external file into the executable and
 //! guarantees that they are aligned.
 //!


### PR DESCRIPTION
Needed to use this in a no_std context. There are no dependencies on std so this was as simple as adding #![no_std].