### PR TITLE
use const instead of static

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@ macro_rules! include_bytes_aligned {
         #[repr(C, align($align_to))]
         struct __Aligned<T: ?Sized>(T);
 
-        static __DATA: &'static __Aligned<[u8]> = &__Aligned(*include_bytes!($path));
+        const __DATA: &'static __Aligned<[u8]> = &__Aligned(*include_bytes!($path));
 
         &__DATA.0
     }};


### PR DESCRIPTION
Using static seems to cause compiler error in late rust versions.