### PR TITLE
Keep length of included bytes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,8 @@ macro_rules! include_bytes_aligned {
         #[repr(C, align($align_to))]
         struct __Aligned<T: ?Sized>(T);
 
-        const __DATA: &'static __Aligned<[u8]> = &__Aligned(*include_bytes!($path));
+        const __DATA: &'static __Aligned<[u8; include_bytes!($path).len()]> =
+            &__Aligned(*include_bytes!($path));
 
         &__DATA.0
     }};


### PR DESCRIPTION
Doing so allows you to obtain an array from the included bytes, as in 
`const FOO: [u8; include_bytes_aligned(16, "foo.bin")] = *include_bytes_aligned(16, "foo.bin");`